### PR TITLE
Cleanup Workspace Task Parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           deno-version: v2.0.0-rc.9
 
       - name: Run Tests
-        run: deno test
+        run: deno run test:ci
 
   lint:
     name: Lint

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsm-hcd/spino",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": "./main.ts",
   "tasks": {
     "test": "deno run test:ci --watch",

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -2,9 +2,14 @@
   "name": "@rsm-hcd/spino",
   "version": "0.1.2",
   "exports": "./main.ts",
+  "tasks": {
+    "test": "deno run test:ci --watch",
+    "test:ci": "deno test --allow-read"
+  },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1",
     "@std/fmt": "jsr:@std/fmt@^1",
+    "@std/path": "jsr:@std/path@^1",
     "@std/streams": "jsr:@std/streams@^1",
     "@std/testing": "jsr:@std/testing@^1"
   },

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -7,7 +7,9 @@ const rootCwd = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 
 Deno.args.forEach((arg) => {
-  const foundTasks = findAllTasks(rootCwd).filter(({ task }) => task === arg);
+  const foundTasks = findAllTasks({ cwd: rootCwd }).filter(({ task }) =>
+    task === arg
+  );
 
   if (foundTasks.length === 0) {
     console.log(`Task "${arg}" not found.`);

--- a/cli/package-parser.ts
+++ b/cli/package-parser.ts
@@ -1,0 +1,64 @@
+import * as path from "@std/path";
+import type { Task } from "./types.ts";
+
+export function parse(
+  filePath: string,
+  relativeFolderName: string,
+  cwd: string,
+): Task[] {
+  switch (path.basename(filePath)) {
+    case "package.json":
+      return parsePackageJson(filePath, relativeFolderName, cwd);
+    case "deno.json":
+      return parseDenoJson(filePath, relativeFolderName, cwd);
+    default:
+      return [];
+  }
+}
+
+function parsePackageJson(
+  filePath: string,
+  relativeFolderName: string,
+  cwd: string,
+): Task[] {
+  const tasks: Task[] = [];
+  const contents = Deno.readTextFileSync(filePath);
+  const json = JSON.parse(contents);
+  const { scripts, ...pkg } = json;
+
+  if (scripts) {
+    for (const name in scripts) {
+      tasks.push({
+        package: pkg.name ?? relativeFolderName,
+        task: name,
+        script: scripts[name],
+        cwd,
+      });
+    }
+  }
+
+  return tasks;
+}
+
+function parseDenoJson(
+  filePath: string,
+  relativeFolderName: string,
+  cwd: string,
+): Task[] {
+  const tasks: Task[] = [];
+  const contents = Deno.readTextFileSync(filePath);
+  const json = JSON.parse(contents);
+  const { tasks: denoTasks, name: denoPackageName } = json;
+
+  if (denoTasks) {
+    for (const name in denoTasks) {
+      tasks.push({
+        package: denoPackageName ?? relativeFolderName,
+        task: name,
+        script: denoTasks[name],
+        cwd,
+      });
+    }
+  }
+  return tasks;
+}

--- a/cli/test-files/deno-nested/deno.json
+++ b/cli/test-files/deno-nested/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rsm-hcd/stub-deno-nested",
+  "tasks": {
+    "dev": "deno eval \"console.log('dev called in stub-deno-nested')\"",
+    "dev2": "deno eval \"console.log('dev2 called in stub-deno-nested')\""
+  }
+}

--- a/cli/test-files/deno.json
+++ b/cli/test-files/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rsm-hcd/deno-stub",
+  "tasks": {
+    "dev": "deno eval \"console.log('dev called in deno-stub')\"",
+    "dev2": "deno eval \"console.log('dev2 called in deno-stub')\""
+  }
+}

--- a/cli/test-files/node-nested/package.json
+++ b/cli/test-files/node-nested/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rsm-hcd/stub-node-nested",
+  "scripts": {
+    "dev": "deno eval \"console.log('dev called in stub-node-nested')\"",
+    "dev2": "deno eval \"console.log('dev2 called in stub-node-nested')\""
+  }
+}

--- a/cli/workspace.test.ts
+++ b/cli/workspace.test.ts
@@ -1,22 +1,17 @@
 import { assertEquals } from "@std/assert";
-import { describe, it } from "@std/testing/bdd";
+import { before, describe, it } from "@std/testing/bdd";
+import * as path from "@std/path";
 import { findAllTasks } from "./workspace.ts";
 
 describe("cli/workspace", () => {
+  let cwd: string;
+
+  before(() => {
+    cwd = path.join(Deno.cwd(), "test-files");
+  });
+
   it("should find all tasks in a workspace", () => {
-    const tasks = findAllTasks(Deno.cwd());
-    assertEquals(Array.isArray(tasks), true);
-  });
-
-  it("should parse package.json files correctly", () => {
-    const tasks = findAllTasks(Deno.cwd());
-    const packageJsonTasks = tasks.filter(task => task.script.includes("package.json"));
-    assertEquals(packageJsonTasks.length > 0, true);
-  });
-
-  it("should parse deno.json files correctly", () => {
-    const tasks = findAllTasks(Deno.cwd());
-    const denoJsonTasks = tasks.filter(task => task.script.includes("deno.json"));
-    assertEquals(denoJsonTasks.length > 0, true);
+    const tasks = findAllTasks({ cwd });
+    assertEquals(tasks.length, 4);
   });
 });

--- a/cli/workspace.test.ts
+++ b/cli/workspace.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { findAllTasks } from "./workspace.ts";
+
+describe("cli/workspace", () => {
+  it("should find all tasks in a workspace", () => {
+    const tasks = findAllTasks(Deno.cwd());
+    assertEquals(Array.isArray(tasks), true);
+  });
+
+  it("should parse package.json files correctly", () => {
+    const tasks = findAllTasks(Deno.cwd());
+    const packageJsonTasks = tasks.filter(task => task.script.includes("package.json"));
+    assertEquals(packageJsonTasks.length > 0, true);
+  });
+
+  it("should parse deno.json files correctly", () => {
+    const tasks = findAllTasks(Deno.cwd());
+    const denoJsonTasks = tasks.filter(task => task.script.includes("deno.json"));
+    assertEquals(denoJsonTasks.length > 0, true);
+  });
+});

--- a/cli/workspace.ts
+++ b/cli/workspace.ts
@@ -32,37 +32,12 @@ function findNestedTasks(cwd: string, rootCwd: string): Task[] {
 
     try {
       if (entry.isFile && entry.name === "package.json") {
-        const pkg = JSON.parse(
-          Deno.readTextFileSync(`${cwd}/${entry.name}`),
-        );
-        if (pkg.scripts) {
-          for (const name in pkg.scripts) {
-            tasks.push({
-              package: pkg.name ?? relativeFolderName,
-              task: name,
-              script: pkg.scripts[name],
-              cwd,
-            });
-          }
-        }
-
+        tasks.push(...parsePackageJson(`${cwd}/${entry.name}`, relativeFolderName));
         continue;
       }
 
       if (entry.isFile && entry.name === "deno.json") {
-        const { tasks: denoTasks, name: denoPackageName } = JSON.parse(
-          Deno.readTextFileSync(`${cwd}/${entry.name}`),
-        );
-        if (denoTasks) {
-          for (const name in denoTasks) {
-            tasks.push({
-              package: denoPackageName ?? relativeFolderName,
-              task: name,
-              script: denoTasks[name],
-              cwd,
-            });
-          }
-        }
+        tasks.push(...parseDenoJson(`${cwd}/${entry.name}`, relativeFolderName));
       }
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
@@ -73,5 +48,37 @@ function findNestedTasks(cwd: string, rootCwd: string): Task[] {
     }
   }
 
+  return tasks;
+}
+
+function parsePackageJson(filePath: string, relativeFolderName: string): Task[] {
+  const tasks: Task[] = [];
+  const pkg = JSON.parse(Deno.readTextFileSync(filePath));
+  if (pkg.scripts) {
+    for (const name in pkg.scripts) {
+      tasks.push({
+        package: pkg.name ?? relativeFolderName,
+        task: name,
+        script: pkg.scripts[name],
+        cwd: filePath.slice(0, filePath.lastIndexOf('/')),
+      });
+    }
+  }
+  return tasks;
+}
+
+function parseDenoJson(filePath: string, relativeFolderName: string): Task[] {
+  const tasks: Task[] = [];
+  const { tasks: denoTasks, name: denoPackageName } = JSON.parse(Deno.readTextFileSync(filePath));
+  if (denoTasks) {
+    for (const name in denoTasks) {
+      tasks.push({
+        package: denoPackageName ?? relativeFolderName,
+        task: name,
+        script: denoTasks[name],
+        cwd: filePath.slice(0, filePath.lastIndexOf('/')),
+      });
+    }
+  }
   return tasks;
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,8 @@
 {
   "tasks": {
-    "spino": "deno -A ./cli/main.ts"
+    "spino": "deno -A ./cli/main.ts",
+    "test": "deno run spino test",
+    "test:ci": "deno run spino test:ci"
   },
   "workspace": [
     "./cli"

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,8 @@
     "jsr:@std/assert@^1.0.6": "1.0.6",
     "jsr:@std/fmt@1": "1.0.2",
     "jsr:@std/internal@^1.0.4": "1.0.4",
+    "jsr:@std/path@*": "1.0.6",
+    "jsr:@std/path@1": "1.0.6",
     "jsr:@std/streams@1": "1.0.6",
     "jsr:@std/testing@1": "1.0.3"
   },
@@ -20,6 +22,9 @@
     },
     "@std/internal@1.0.4": {
       "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
+    },
+    "@std/path@1.0.6": {
+      "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
     },
     "@std/streams@1.0.6": {
       "integrity": "022ed94e380d06b4d91c49eb70241b7289ab78b8c2b4c4bbb7eb265e4997c25c"
@@ -38,6 +43,7 @@
         "dependencies": [
           "jsr:@std/assert@1",
           "jsr:@std/fmt@1",
+          "jsr:@std/path@1",
           "jsr:@std/streams@1",
           "jsr:@std/testing@1"
         ]


### PR DESCRIPTION
Fixes #1

Refactor workspace task parser to reduce code duplication and add tests.

* Create `parsePackageJson` function to parse `package.json` files.
* Create `parseDenoJson` function to parse `deno.json` files.
* Replace code that parses `package.json` and `deno.json` files with calls to `parsePackageJson` and `parseDenoJson`.
* Add tests for `findAllTasks`, `parsePackageJson`, and `parseDenoJson` functions in `cli/workspace.test.ts`.
* Add `package-parser`