### PR TITLE
Refactor logging in CLI

### DIFF
--- a/cli/prefix-logger.test.ts
+++ b/cli/prefix-logger.test.ts
@@ -1,0 +1,26 @@
+import { assertSpyCall, type MethodSpy, spy } from "@std/testing/mock";
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { PrefixLogger } from "./prefix-logger.ts";
+
+describe("cli/prefix-logger", () => {
+  let logSpy: MethodSpy<Console, unknown[], void>;
+
+  beforeAll(() => {
+    logSpy = spy(console, "log");
+  });
+
+  it("should log messages with a prefix", () => {
+    // Arrange
+    const prefix = "test";
+    const message = "Hello, world!";
+    const logger = new PrefixLogger(prefix);
+
+    // Act
+    logger.log("Hello, world!");
+
+    // Assert
+    assertSpyCall(logSpy, 0, {
+      args: [`${logger.prefix} ${message}`],
+    });
+  });
+});

--- a/cli/prefix-logger.ts
+++ b/cli/prefix-logger.ts
@@ -1,0 +1,40 @@
+import * as colors from "@std/fmt/colors";
+import { randomColor } from "./colors.ts";
+
+export class PrefixLogger {
+  private readonly decoder = new TextDecoder("utf-8");
+
+  readonly prefix: string;
+
+  constructor(prefix: string) {
+    const consoleColor = colors[randomColor()] as (str: string) => string;
+    this.prefix = consoleColor(
+      `${prefix}:`,
+    );
+  }
+
+  log(message: string | Uint8Array) {
+    this.console(console.log, message);
+  }
+
+  error(message: string | Uint8Array) {
+    this.console(console.error, message);
+  }
+
+  private console(
+    consoleFunc: (...args: unknown[]) => void,
+    message: string | Uint8Array,
+  ) {
+    const decoded = typeof message === "string"
+      ? message
+      : this.decoder.decode(message, { stream: true });
+
+    for (const line of decoded.split("\n")) {
+      if (!line) {
+        continue;
+      }
+
+      consoleFunc(`${this.prefix} ${line}`);
+    }
+  }
+}


### PR DESCRIPTION
- Remove unused imports and variables
- Replace console.log and console.error calls with PrefixLogger class in CLI main.ts
- Add PrefixLogger class to provide logging with a prefix in CLI prefix-logger.ts