### PR TITLE
Organize into cli commands and add help command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           deno-version: v2.0.0-rc.9
 
       - name: Run Tests
-        run: deno run test:ci
+        run: deno task test:ci
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Once installed, you can run the `spino` command from the terminal to run any
 tasks or scripts that match the provided name.
 
 ```sh
-# Run all dev tasks
-spino dev
+# Run a specific task
+> spino dev
 
 # Run all dev and test tasks
-spino dev test
+> spino dev test
+
+# See help information
+> spino --help
+Usage: spino [task1] [task2] ...
 ```
 
 Or, you can run, without installing globally, by adding to the tasks section of

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ your `deno.json` file.
 {
   "tasks": {
     "spino": "deno --allow-read --allow-run='deno' jsr:@rsm-hcd/spino",
-    "test": "deno run spino test"
+    "test": "deno task spino test"
   }
 }
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,11 +16,15 @@ Once installed, you can run the `spino` command from the terminal to run any
 tasks or scripts that match the provided name.
 
 ```sh
-# Run all dev tasks
-spino dev
+# Run a specific task
+> spino dev
 
 # Run all dev and test tasks
-spino dev test
+> spino dev test
+
+# See help information
+> spino --help
+Usage: spino [task1] [task2] ...
 ```
 
 Or, you can run, without installing globally, by adding to the tasks section of
@@ -30,7 +34,7 @@ your `deno.json` file.
 {
   "tasks": {
     "spino": "deno --allow-read --allow-run='deno' jsr:@rsm-hcd/spino",
-    "test": "deno run spino test"
+    "test": "deno task spino test"
   }
 }
 ```

--- a/cli/commands/help.ts
+++ b/cli/commands/help.ts
@@ -1,0 +1,3 @@
+export function displayHelpCommand() {
+  console.log(`Usage: spino [task1] [task2] ...`);
+}

--- a/cli/commands/tasks.ts
+++ b/cli/commands/tasks.ts
@@ -1,0 +1,60 @@
+import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
+import { findAllTasks } from "../workspace.ts";
+import { PrefixLogger } from "../prefix-logger.ts";
+
+export async function runTasks(rootCwd: string, tasks: string[]) {
+  const allRunningTasks = tasks.flatMap((taskName) => {
+    const foundTasks = findAllTasks({ cwd: rootCwd }).filter((p) =>
+      p.task === taskName
+    );
+
+    if (foundTasks.length === 0) {
+      console.log(`Task "${taskName}" not found.`);
+      Deno.exit(1);
+    }
+
+    // Run all tasks in parallel
+    const runningTasks = foundTasks.map(
+      async ({ package: taskPackageName, task, cwd }) => {
+        const logger = new PrefixLogger(taskPackageName);
+        const command = new Deno.Command("deno", {
+          cwd,
+          args: ["task", task],
+          stdout: "piped",
+          stderr: "piped",
+        });
+
+        const { status, stdout, stderr } = command.spawn();
+
+        await mergeReadableStreams(stdout, stderr)
+          .pipeTo(
+            new WritableStream<Uint8Array>(
+              {
+                write(chunk) {
+                  return new Promise((resolve) => {
+                    logger.log(chunk);
+                    resolve();
+                  });
+                },
+                abort(err) {
+                  logger.error(`${err}`);
+                },
+              },
+            ),
+          );
+
+        const { success } = await status;
+
+        if (!success) {
+          logger.error(`Failed to run task "${task}".`);
+          Deno.exit(1);
+        }
+      },
+    );
+
+    return runningTasks;
+  });
+
+  // Wait for all tasks to finish
+  await Promise.all(allRunningTasks);
+}

--- a/cli/commands/tasks.ts
+++ b/cli/commands/tasks.ts
@@ -2,7 +2,7 @@ import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
 import { findAllTasks } from "../workspace.ts";
 import { PrefixLogger } from "../prefix-logger.ts";
 
-export async function runTasks(rootCwd: string, tasks: string[]) {
+export async function runTasksCommand(rootCwd: string, tasks: string[]) {
   const allRunningTasks = tasks.flatMap((taskName) => {
     const foundTasks = findAllTasks({ cwd: rootCwd }).filter((p) =>
       p.task === taskName

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -3,11 +3,12 @@
   "version": "0.1.4",
   "exports": "./main.ts",
   "tasks": {
-    "test": "deno run test:ci --watch",
+    "test": "deno task test:ci --watch",
     "test:ci": "deno test --allow-read"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1",
+    "@std/cli": "jsr:@std/cli@^1",
     "@std/fmt": "jsr:@std/fmt@^1",
     "@std/path": "jsr:@std/path@^1",
     "@std/streams": "jsr:@std/streams@^1",

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,12 +1,13 @@
 import { parseArgs } from "@std/cli/parse-args";
-import { runTasks } from "./commands/tasks.ts";
+import { displayHelpCommand } from "./commands/help.ts";
+import { runTasksCommand } from "./commands/tasks.ts";
 
 const rootCwd = Deno.cwd();
 const { help, _: tasks } = parseArgs(Deno.args);
 
 if (help || tasks.length === 0) {
-  console.log(`Usage: spino [task1] [task2] ...`);
+  displayHelpCommand();
   Deno.exit(0);
 }
 
-await runTasks(rootCwd, tasks as string[]);
+await runTasksCommand(rootCwd, tasks as string[]);

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,57 +1,12 @@
-import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
-import { findAllTasks } from "./workspace.ts";
-import { PrefixLogger } from "./prefix-logger.ts";
+import { parseArgs } from "@std/cli/parse-args";
+import { runTasks } from "./commands/tasks.ts";
 
 const rootCwd = Deno.cwd();
+const { help, _: tasks } = parseArgs(Deno.args);
 
-for (const arg of Deno.args) {
-  const foundTasks = findAllTasks({ cwd: rootCwd }).filter(({ task }) =>
-    task === arg
-  );
-
-  if (foundTasks.length === 0) {
-    console.log(`Task "${arg}" not found.`);
-    Deno.exit(1);
-  }
-
-  // Run all tasks in parallel
-  const runningTasks = foundTasks.map(
-    async ({ package: taskPackageName, task, cwd }) => {
-      const logger = new PrefixLogger(taskPackageName);
-      const command = new Deno.Command("deno", {
-        cwd,
-        args: ["run", task],
-        stdout: "piped",
-        stderr: "piped",
-      });
-
-      const { status, stdout, stderr } = command.spawn();
-
-      await mergeReadableStreams(stdout, stderr)
-        .pipeTo(
-          new WritableStream<Uint8Array>(
-            {
-              write(chunk) {
-                return new Promise((resolve) => {
-                  logger.log(chunk);
-                  resolve();
-                });
-              },
-              abort(err) {
-                logger.error(`${err}`);
-              },
-            },
-          ),
-        );
-
-      const { success } = await status;
-
-      if (!success) {
-        logger.error(`Failed to run task "${task}".`);
-        Deno.exit(1);
-      }
-    },
-  );
-
-  await Promise.all(runningTasks);
+if (help || tasks.length === 0) {
+  console.log(`Usage: spino [task1] [task2] ...`);
+  Deno.exit(0);
 }
+
+await runTasks(rootCwd, tasks as string[]);

--- a/cli/workspace.test.ts
+++ b/cli/workspace.test.ts
@@ -7,7 +7,13 @@ describe("cli/workspace", () => {
   let cwd: string;
 
   before(() => {
-    cwd = path.join(Deno.cwd(), "test-files");
+    const { dirname } = import.meta;
+
+    if (dirname === undefined) {
+      throw new Error("import.meta.dirname is undefined");
+    }
+
+    cwd = path.join(dirname, "test-files");
   });
 
   it("should find all tasks in a workspace", () => {

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "tasks": {
     "spino": "deno -A ./cli/main.ts",
-    "test": "deno run spino test",
-    "test:ci": "deno run spino test:ci"
+    "test": "deno task spino test",
+    "test:ci": "deno task spino test:ci"
   },
   "workspace": [
     "./cli"

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@std/assert@1": "1.0.6",
     "jsr:@std/assert@^1.0.6": "1.0.6",
+    "jsr:@std/cli@1": "1.0.6",
     "jsr:@std/fmt@1": "1.0.2",
     "jsr:@std/internal@^1.0.4": "1.0.4",
     "jsr:@std/path@*": "1.0.6",
@@ -16,6 +17,9 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/cli@1.0.6": {
+      "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
     },
     "@std/fmt@1.0.2": {
       "integrity": "87e9dfcdd3ca7c066e0c3c657c1f987c82888eb8103a3a3baa62684ffeb0f7a7"
@@ -42,6 +46,7 @@
       "cli": {
         "dependencies": [
           "jsr:@std/assert@1",
+          "jsr:@std/cli@1",
           "jsr:@std/fmt@1",
           "jsr:@std/path@1",
           "jsr:@std/streams@1",


### PR DESCRIPTION
Fixes: #5

This pull request refactors the CLI main.ts file to use the @std/cli/parse-args library for parsing command line arguments. It adds a help cli flag to improve the dx. It also moves the task running logic to a separate file and adds a help command. This improves the code organization and makes it easier to add new commands in the future.