### PR TITLE
Add upgrade command and command parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ tasks or scripts that match the provided name.
 # Run all dev and test tasks
 > spino dev test
 
+# Upgrade spino
+> spino upgrade
+
 # See help information
-> spino --help
+> spino [command] --help
 Usage: spino [task1] [task2] ...
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,8 +32,11 @@ tasks or scripts that match the provided name.
 # Run all dev and test tasks
 > spino dev test
 
+# Upgrade spino
+> spino upgrade
+
 # See help information
-> spino --help
+> spino [command] --help
 Usage: spino [task1] [task2] ...
 ```
 

--- a/cli/command-parser.test.ts
+++ b/cli/command-parser.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "@std/testing/bdd";
+import { parseCommands } from "./command-parser.ts";
+import { assertEquals } from "@std/assert/equals";
+
+describe("cli/parseCommands", () => {
+  it("should return help true when --help is passed", () => {
+    // Arrange
+    const args = ["--help"];
+
+    // Act
+    const result = parseCommands(args);
+
+    // Assert
+    assertEquals(result.help, true);
+  });
+
+  it("should return command upgrade when upgrade is passed", () => {
+    // Arrange
+    const args = ["upgrade"];
+
+    // Act
+    const result = parseCommands(args);
+
+    // Assert
+    assertEquals(result.command, "upgrade");
+  });
+
+  it("should return tasks when tasks are passed", () => {
+    // Arrange
+    const args = ["task1", "task2"];
+
+    // Act
+    const result = parseCommands(args);
+
+    // Assert
+    assertEquals(result.tasks, ["task1", "task2"]);
+  });
+});

--- a/cli/command-parser.ts
+++ b/cli/command-parser.ts
@@ -1,0 +1,25 @@
+import { parseArgs } from "@std/cli/parse-args";
+
+interface ParsedCommands {
+  help: boolean;
+  command?: "upgrade";
+  tasks: string[];
+}
+
+export function parseCommands(args: string[]): ParsedCommands {
+  const { help, _ } = parseArgs(args);
+
+  const { upgrade, tasks } = _.reduce((acc, arg) => {
+    if (arg === "upgrade") {
+      return { ...acc, upgrade: true };
+    }
+
+    return { ...acc, tasks: [...acc.tasks, `${arg}`] };
+  }, { tasks: [] as string[], upgrade: false });
+
+  return {
+    help,
+    command: upgrade ? "upgrade" : undefined,
+    tasks,
+  };
+}

--- a/cli/commands/help.ts
+++ b/cli/commands/help.ts
@@ -1,3 +1,12 @@
-export function displayHelpCommand() {
-  console.log(`Usage: spino [task1] [task2] ...`);
+const updgradeHelpMessage = `Upgrade spino to the latest version`;
+
+export function displayHelpCommand(command?: string) {
+  if (command === "upgrade") {
+    console.log(`Usage: spino upgrade\n\n${updgradeHelpMessage}`);
+    return;
+  }
+
+  console.log(
+    `Usage: spino [task1] [task2] or spino [command]\n\nCommands:\n  upgrade: ${updgradeHelpMessage}`,
+  );
 }

--- a/cli/commands/upgrade.ts
+++ b/cli/commands/upgrade.ts
@@ -1,0 +1,8 @@
+export function upgradeCommand(source: string) {
+  const command = new Deno.Command("deno", {
+    args: ["cache", "--reload", source],
+  });
+
+  command.outputSync();
+  console.log("Update spino to latest version");
+}

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsm-hcd/spino",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "exports": "./main.ts",
   "tasks": {
     "test": "deno task test:ci --watch",

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,13 +1,19 @@
-import { parseArgs } from "@std/cli/parse-args";
+import { parseCommands } from "./command-parser.ts";
 import { displayHelpCommand } from "./commands/help.ts";
 import { runTasksCommand } from "./commands/tasks.ts";
+import { upgradeCommand } from "./commands/upgrade.ts";
 
 const rootCwd = Deno.cwd();
-const { help, _: tasks } = parseArgs(Deno.args);
+const { help, command, tasks } = parseCommands(Deno.args);
 
-if (help || tasks.length === 0) {
-  displayHelpCommand();
+if (!help && command === "upgrade") {
+  upgradeCommand(import.meta.url);
   Deno.exit(0);
 }
 
-await runTasksCommand(rootCwd, tasks as string[]);
+if (help || (command == null && tasks.length === 0)) {
+  displayHelpCommand(command);
+  Deno.exit(0);
+}
+
+await runTasksCommand(rootCwd, tasks);


### PR DESCRIPTION
This pull request adds a new upgrade command and a command parser to the codebase. The upgrade command allows users to update Spino to the latest version, while the command parser parses the arguments passed to the CLI. Additionally, the pull request includes tests for the parseCommands function and updates the displayHelpCommand function to provide usage instructions for the upgrade command.