### PR TITLE
feat:add `list` command to list all workspace tasks grouped by workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   - workflow_dispatch
   - push
+  - pull_request
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ tasks or scripts that match the provided name.
 # Run a specific task
 > spino dev
 
-# Run all dev and test tasks
+# Run all dev and test tasks in parallel
 > spino dev test
 
-# Upgrade spino
-> spino upgrade
-
 # See help information
-> spino [command] --help
-Usage: spino [task1] [task2] ...
+> spino --help
+Usage: spino [task1] [task2] or spino [command]
+
+Commands:
+  upgrade:  Upgrade spino to the latest version
+  list:     List all available workspace tasks
 ```
 
 Or, you can run, without installing globally, by adding to the tasks section of

--- a/cli/command-parser.ts
+++ b/cli/command-parser.ts
@@ -2,24 +2,30 @@ import { parseArgs } from "@std/cli/parse-args";
 
 interface ParsedCommands {
   help: boolean;
-  command?: "upgrade";
+  upgrade: boolean;
+  list: boolean;
+  command?: "upgrade" | "list" | undefined;
   tasks: string[];
 }
 
 export function parseCommands(args: string[]): ParsedCommands {
   const { help, _ } = parseArgs(args);
 
-  const { upgrade, tasks } = _.reduce((acc, arg) => {
-    if (arg === "upgrade") {
-      return { ...acc, upgrade: true };
+  return _.reduce((acc, arg) => {
+    if (arg == "upgrade" || arg == "list") {
+      return {
+        ...acc,
+        [arg as string]: true,
+        command: arg,
+      };
     }
 
     return { ...acc, tasks: [...acc.tasks, `${arg}`] };
-  }, { tasks: [] as string[], upgrade: false });
-
-  return {
+  }, {
     help,
-    command: upgrade ? "upgrade" : undefined,
-    tasks,
-  };
+    tasks: [],
+    upgrade: false,
+    list: false,
+    command: undefined,
+  } as ParsedCommands);
 }

--- a/cli/commands/help.ts
+++ b/cli/commands/help.ts
@@ -1,12 +1,19 @@
 const updgradeHelpMessage = `Upgrade spino to the latest version`;
+const listAllTasksMessage = `List all available workspace tasks`;
 
 export function displayHelpCommand(command?: string) {
   if (command === "upgrade") {
     console.log(`Usage: spino upgrade\n\n${updgradeHelpMessage}`);
     return;
   }
+  if (command === "list") {
+    console.log(`Usage: spino list\n\n${listAllTasksMessage}`);
+    return;
+  }
 
   console.log(
-    `Usage: spino [task1] [task2] or spino [command]\n\nCommands:\n  upgrade: ${updgradeHelpMessage}`,
+    `Usage: spino [task1] [task2] or spino [command]\n\nCommands:
+  upgrade:  ${updgradeHelpMessage}
+  list:     ${listAllTasksMessage}`,
   );
 }

--- a/cli/commands/list.ts
+++ b/cli/commands/list.ts
@@ -21,12 +21,8 @@ export async function listCommand(rootCwd: string) {
   }, {} as Record<string, Task[]>);
 
   // Calculate the max length of all task names
-  const taskNames: string[] = [];
-  Object.entries(groupedTasks).forEach(([_, workspaceTasks]) => {
-    workspaceTasks.forEach((task) => {
-      taskNames.push(task.task);
-    });
-  });
+  const taskNames: string[] = Object.values(groupedTasks)
+    .flatMap((workspaceTasks) => workspaceTasks.map((task) => task.task));
   const maxTaskNameLength = Math.max(...taskNames.map((name) => name.length));
 
   // Log each task with left-aligned script

--- a/cli/commands/list.ts
+++ b/cli/commands/list.ts
@@ -1,0 +1,45 @@
+import { findAllWorkspaceTasks } from "../workspace.ts";
+import { PrefixLogger } from "../prefix-logger.ts";
+import type { Task } from "../types.ts";
+
+export async function listCommand(rootCwd: string) {
+    // TODO: Include root tasks
+    const allWorkspaceTasks = await findAllWorkspaceTasks({ cwd: rootCwd });
+
+    if (allWorkspaceTasks.length === 0) {
+        console.log(`No tasks found`);
+        Deno.exit(1);
+    }
+
+    // Group package tasks by workspace
+    const groupedTasks = allWorkspaceTasks.reduce((acc, task) => {
+        if (!acc[task.package]) {
+            acc[task.package] = [];
+        }
+        acc[task.package].push(task);
+        return acc;
+    }, {} as Record<string, Task[]>);
+
+    // Calculate the max length of all task names
+    const taskNames: string[] = [];
+    Object.entries(groupedTasks).forEach(([_, workspaceTasks]) => {
+        workspaceTasks.forEach((task) => {
+            taskNames.push(task.task);
+        });
+    });
+    const maxTaskNameLength = Math.max(...taskNames.map((name) => name.length));
+
+    // Log each task with left-aligned script
+    Object.entries(groupedTasks).map(([workspace, workspaceTasks]) => {
+        console.log(`${workspace}:`);
+        workspaceTasks.forEach((workspaceTask) => {
+            const { task, script } = workspaceTask;
+            const taskLogger = new PrefixLogger(task.padStart(task.length + 4));
+            taskLogger.log(
+                script.padStart(
+                    maxTaskNameLength - task.length + script.length + 4,
+                ),
+            );
+        });
+    });
+}

--- a/cli/commands/list.ts
+++ b/cli/commands/list.ts
@@ -3,43 +3,43 @@ import { PrefixLogger } from "../prefix-logger.ts";
 import type { Task } from "../types.ts";
 
 export async function listCommand(rootCwd: string) {
-    // TODO: Include root tasks
-    const allWorkspaceTasks = await findAllWorkspaceTasks({ cwd: rootCwd });
+  // TODO: Include root tasks
+  const allWorkspaceTasks = await findAllWorkspaceTasks({ cwd: rootCwd });
 
-    if (allWorkspaceTasks.length === 0) {
-        console.log(`No tasks found`);
-        Deno.exit(1);
+  if (allWorkspaceTasks.length === 0) {
+    console.log(`No tasks found`);
+    return;
+  }
+
+  // Group package tasks by workspace
+  const groupedTasks = allWorkspaceTasks.reduce((acc, task) => {
+    if (!acc[task.package]) {
+      acc[task.package] = [];
     }
+    acc[task.package].push(task);
+    return acc;
+  }, {} as Record<string, Task[]>);
 
-    // Group package tasks by workspace
-    const groupedTasks = allWorkspaceTasks.reduce((acc, task) => {
-        if (!acc[task.package]) {
-            acc[task.package] = [];
-        }
-        acc[task.package].push(task);
-        return acc;
-    }, {} as Record<string, Task[]>);
-
-    // Calculate the max length of all task names
-    const taskNames: string[] = [];
-    Object.entries(groupedTasks).forEach(([_, workspaceTasks]) => {
-        workspaceTasks.forEach((task) => {
-            taskNames.push(task.task);
-        });
+  // Calculate the max length of all task names
+  const taskNames: string[] = [];
+  Object.entries(groupedTasks).forEach(([_, workspaceTasks]) => {
+    workspaceTasks.forEach((task) => {
+      taskNames.push(task.task);
     });
-    const maxTaskNameLength = Math.max(...taskNames.map((name) => name.length));
+  });
+  const maxTaskNameLength = Math.max(...taskNames.map((name) => name.length));
 
-    // Log each task with left-aligned script
-    Object.entries(groupedTasks).map(([workspace, workspaceTasks]) => {
-        console.log(`${workspace}:`);
-        workspaceTasks.forEach((workspaceTask) => {
-            const { task, script } = workspaceTask;
-            const taskLogger = new PrefixLogger(task.padStart(task.length + 4));
-            taskLogger.log(
-                script.padStart(
-                    maxTaskNameLength - task.length + script.length + 4,
-                ),
-            );
-        });
+  // Log each task with left-aligned script
+  Object.entries(groupedTasks).map(([workspace, workspaceTasks]) => {
+    console.log(`${workspace}:`);
+    workspaceTasks.forEach((workspaceTask) => {
+      const { task, script } = workspaceTask;
+      const taskLogger = new PrefixLogger(task.padStart(task.length + 4));
+      taskLogger.log(
+        script.padStart(
+          maxTaskNameLength - task.length + script.length + 4,
+        ),
+      );
     });
+  });
 }

--- a/cli/commands/tasks.ts
+++ b/cli/commands/tasks.ts
@@ -9,7 +9,7 @@ export async function runTasksCommand(rootCwd: string, tasks: string[]) {
     const foundTasks = allWorkspaceTasks.filter((p) => p.task === taskName);
     if (foundTasks.length === 0) {
       console.log(`Task "${taskName}" not found.`);
-      Deno.exit(1);
+      return;
     }
 
     // Run all tasks in parallel

--- a/cli/main.test.ts
+++ b/cli/main.test.ts
@@ -1,0 +1,162 @@
+import { assertRejects } from "@std/assert/rejects";
+import { assertSpyCall, spy } from "@std/testing/mock";
+
+import { parseCommands } from "./command-parser.ts";
+import { displayHelpCommand } from "./commands/help.ts";
+import { listCommand } from "./commands/list.ts";
+import { runTasksCommand } from "./commands/tasks.ts";
+import { upgradeCommand } from "./commands/upgrade.ts";
+
+import { main } from "./main.ts";
+import type { MainCliSpyDependencies } from "./types.ts";
+
+const createMockDeps = (): MainCliSpyDependencies => ({
+  parseCommands: spy(parseCommands),
+  displayHelpCommand: spy(displayHelpCommand),
+  runTasksCommand: spy(runTasksCommand),
+  upgradeCommand: spy(upgradeCommand),
+  listCommand: spy(listCommand),
+});
+
+Deno.test({
+  name: "cli/main - should show help when running with --help flag",
+  fn: async () => {
+    const deps = createMockDeps();
+    const args = ["--help"];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.displayHelpCommand, 0, {
+      args: [undefined],
+    });
+  },
+});
+
+Deno.test({
+  name: "cli/main - should show upgrade help when running with --help flag",
+  fn: async () => {
+    const deps = createMockDeps();
+    const args = ["upgrade", "--help"];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.displayHelpCommand, 0, {
+      args: ["upgrade"],
+    });
+  },
+});
+
+Deno.test({
+  name: "cli/main - should run upgrade command",
+  fn: async () => {
+    const deps = createMockDeps();
+    const args = ["upgrade"];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.upgradeCommand, 0, {
+      args: [],
+    });
+  },
+});
+
+Deno.test({
+  name: "cli/main - should run list command",
+  fn: async () => {
+    const deps = createMockDeps();
+    const args = ["list"];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.listCommand, 0, {
+      args: [Deno.cwd()],
+    });
+  },
+});
+
+Deno.test({
+  name: "cli/main - should run tasks when provided",
+  fn: async () => {
+    const deps = createMockDeps();
+    const args = ["test:ci", "nonexistentTask"];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.runTasksCommand, 0, {
+      args: [Deno.cwd(), ["test:ci", "nonexistentTask"]],
+    });
+  },
+});
+
+Deno.test({
+  name: "cli/main - should show help when no args are provided",
+  fn: async () => {
+    const deps = createMockDeps();
+    const args: string[] = [];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.displayHelpCommand, 0, {
+      args: [undefined],
+    });
+  },
+});
+
+Deno.test({
+  name: "cli/main - should handle errors in list command",
+  fn: async () => {
+    const deps = createMockDeps();
+    deps.listCommand = spy(() => {
+      throw new Error("List command error");
+    });
+
+    const args = ["list"];
+
+    await assertRejects(
+      async () => {
+        await main(deps, args);
+      },
+      Error,
+      "List command error",
+    );
+  },
+});
+
+Deno.test({
+  name: "cli/main - should handle errors in runTasksCommand",
+  fn: async () => {
+    const deps = createMockDeps();
+    deps.runTasksCommand = spy(() => {
+      throw new Error("runTasksCommand error");
+    });
+
+    const args = ["task1"];
+
+    await assertRejects(
+      async () => {
+        await main(deps, args);
+      },
+      Error,
+      "runTasksCommand error",
+    );
+  },
+});
+
+Deno.test({
+  name: "cli/main - should handle invalid commands",
+  fn: async () => {
+    const deps = createMockDeps();
+    deps.parseCommands = spy(() => ({
+      help: false,
+      command: "invalid-command",
+      tasks: [],
+    }));
+    const args = ["invalid-command"];
+
+    await main(deps, args);
+
+    assertSpyCall(deps.runTasksCommand, 0, {
+      args: [Deno.cwd(), []],
+    });
+  },
+});

--- a/cli/main.test.ts
+++ b/cli/main.test.ts
@@ -1,21 +1,15 @@
 import { assertRejects } from "@std/assert/rejects";
 import { assertSpyCall, spy } from "@std/testing/mock";
-
 import { parseCommands } from "./command-parser.ts";
-import { displayHelpCommand } from "./commands/help.ts";
-import { listCommand } from "./commands/list.ts";
-import { runTasksCommand } from "./commands/tasks.ts";
-import { upgradeCommand } from "./commands/upgrade.ts";
-
 import { main } from "./main.ts";
 import type { MainCliSpyDependencies } from "./types.ts";
 
 const createMockDeps = (): MainCliSpyDependencies => ({
   parseCommands: spy(parseCommands),
-  displayHelpCommand: spy(displayHelpCommand),
-  runTasksCommand: spy(runTasksCommand),
-  upgradeCommand: spy(upgradeCommand),
-  listCommand: spy(listCommand),
+  displayHelpCommand: spy(),
+  runTasksCommand: spy(),
+  upgradeCommand: spy(),
+  listCommand: spy(),
 });
 
 Deno.test({

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -2,12 +2,22 @@ import { parseCommands } from "./command-parser.ts";
 import { displayHelpCommand } from "./commands/help.ts";
 import { runTasksCommand } from "./commands/tasks.ts";
 import { upgradeCommand } from "./commands/upgrade.ts";
+import { listCommand } from "./commands/list.ts";
 
 const rootCwd = Deno.cwd();
 const { help, command, tasks } = parseCommands(Deno.args);
 
-if (!help && command === "upgrade") {
-  upgradeCommand(import.meta.url);
+if (!help) {
+  switch (command) {
+    case "upgrade": {
+      upgradeCommand(import.meta.url);
+      break;
+    }
+    case "list": {
+      await listCommand(rootCwd);
+      break;
+    }
+  }
   Deno.exit(0);
 }
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -13,18 +13,18 @@ export async function main(deps: MainCliDependencies, args: string[]) {
     switch (command) {
       case "upgrade": {
         await deps.upgradeCommand();
-        break;
+        return;
       }
       case "list": {
         await deps.listCommand(rootCwd);
-        break;
+        return;
       }
     }
   }
 
   if (help || (command == null && tasks.length === 0)) {
     deps.displayHelpCommand(command);
-    Deno.exit(0);
+    return;
   }
 
   await deps.runTasksCommand(rootCwd, tasks);

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -18,7 +18,6 @@ if (!help) {
       break;
     }
   }
-  Deno.exit(0);
 }
 
 if (help || (command == null && tasks.length === 0)) {

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -3,26 +3,42 @@ import { displayHelpCommand } from "./commands/help.ts";
 import { runTasksCommand } from "./commands/tasks.ts";
 import { upgradeCommand } from "./commands/upgrade.ts";
 import { listCommand } from "./commands/list.ts";
+import type { MainCliDependencies } from "./types.ts";
 
-const rootCwd = Deno.cwd();
-const { help, command, tasks } = parseCommands(Deno.args);
+export async function main(deps: MainCliDependencies, args: string[]) {
+  const rootCwd = Deno.cwd();
+  const { help, command, tasks } = deps.parseCommands(args);
 
-if (!help) {
-  switch (command) {
-    case "upgrade": {
-      await upgradeCommand();
-      break;
-    }
-    case "list": {
-      await listCommand(rootCwd);
-      break;
+  if (!help) {
+    switch (command) {
+      case "upgrade": {
+        await deps.upgradeCommand();
+        break;
+      }
+      case "list": {
+        await deps.listCommand(rootCwd);
+        break;
+      }
     }
   }
+
+  if (help || (command == null && tasks.length === 0)) {
+    deps.displayHelpCommand(command);
+    Deno.exit(0);
+  }
+
+  await deps.runTasksCommand(rootCwd, tasks);
 }
 
-if (help || (command == null && tasks.length === 0)) {
-  displayHelpCommand(command);
-  Deno.exit(0);
-}
+// Only run if this is the main module
+if (import.meta.main) {
+  const deps: MainCliDependencies = {
+    parseCommands,
+    displayHelpCommand,
+    runTasksCommand,
+    upgradeCommand,
+    listCommand,
+  };
 
-await runTasksCommand(rootCwd, tasks);
+  await main(deps, Deno.args);
+}

--- a/cli/prefix-logger.ts
+++ b/cli/prefix-logger.ts
@@ -6,11 +6,11 @@ export class PrefixLogger {
 
   readonly prefix: string;
 
-  constructor(packageName: string, taskName: string) {
+  constructor(packageName: string, taskName?: string) {
     const consoleColor = colors[randomColor()] as (str: string) => string;
-    this.prefix = consoleColor(
-      `${packageName}:${taskName}:`,
-    );
+    let prefix = `${packageName}:`;
+    prefix += taskName ? `${taskName}:` : "";
+    this.prefix = consoleColor(prefix);
   }
 
   log(message: string | Uint8Array) {

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -3,6 +3,7 @@ import type { displayHelpCommand } from "./commands/help.ts";
 import type { runTasksCommand } from "./commands/tasks.ts";
 import type { upgradeCommand } from "./commands/upgrade.ts";
 import type { listCommand } from "./commands/list.ts";
+import type { Spy } from "@std/testing/mock";
 
 export interface MainCliDependencies {
   parseCommands: typeof parseCommands;
@@ -10,6 +11,14 @@ export interface MainCliDependencies {
   runTasksCommand: typeof runTasksCommand;
   upgradeCommand: typeof upgradeCommand;
   listCommand: typeof listCommand;
+}
+
+export interface MainCliSpyDependencies {
+  parseCommands: Spy<typeof parseCommands>;
+  displayHelpCommand: Spy<typeof displayHelpCommand>;
+  runTasksCommand: Spy<typeof runTasksCommand>;
+  upgradeCommand: Spy<typeof upgradeCommand>;
+  listCommand: Spy<typeof listCommand>;
 }
 
 export interface Task {

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -1,3 +1,17 @@
+import type { parseCommands } from "./command-parser.ts";
+import type { displayHelpCommand } from "./commands/help.ts";
+import type { runTasksCommand } from "./commands/tasks.ts";
+import type { upgradeCommand } from "./commands/upgrade.ts";
+import type { listCommand } from "./commands/list.ts";
+
+export interface MainCliDependencies {
+  parseCommands: typeof parseCommands;
+  displayHelpCommand: typeof displayHelpCommand;
+  runTasksCommand: typeof runTasksCommand;
+  upgradeCommand: typeof upgradeCommand;
+  listCommand: typeof listCommand;
+}
+
 export interface Task {
   package: string;
   task: string;


### PR DESCRIPTION
This will close [feat: add command to list all tasks](https://github.com/rsm-hcd/spino/issues/11).

### Current Behavior:
No command exists to list all the available workspace tasks

### Expected Behavior:
Run `spino list` to display all available workspace tasks

Example output:
```
@rsm-hcd/spino:
    test:        deno task test:ci --watch
    test:ci:     deno test --allow-read
```

### Related Notes/Future issues:
- [ ] Include root `deno.json` tasks (`list` and running `spino [TASK]` should include this)
- [ ] Potentially handle nested workspaces and indent them by depth level?